### PR TITLE
 [1.2.2][1.2.5] Add endpoints for create and destroy comments

### DIFF
--- a/app/controllers/api/v1/author/comments_controller.rb
+++ b/app/controllers/api/v1/author/comments_controller.rb
@@ -1,0 +1,37 @@
+class Api::V1::Author::CommentsController < Api::V1::Author::BaseController
+  def create
+    comment = current_user.comments.build(comment_params)
+    comment.commentable = parent
+
+    return render_error 'Post not found', 406 if parent.blank?
+
+    if comment.save
+      render_success 'Comment was succesfully created', 201
+    else
+      render json: { errors: comment.errors.full_messages }, status: 406
+    end
+  end
+
+  def destroy
+    comment = current_user.comments.find_by(id: params[:comment_id])
+
+    return render_error 'Comment not found' unless comment.present?
+
+    comment.destroy
+
+    render_success 'Comment was succesfully destroyed', 200
+  end
+
+  private
+
+  def parent
+    @parent ||=
+      if params[:post_id].present?
+        Post.find_by(id: params[:post_id])
+      end
+  end
+
+  def comment_params
+    params.require(:comment).permit(:body)
+  end
+end

--- a/app/controllers/api/v1/author/posts_controller.rb
+++ b/app/controllers/api/v1/author/posts_controller.rb
@@ -1,8 +1,6 @@
 class Api::V1::Author::PostsController < Api::V1::Author::BaseController
   include PostsHelper
 
-  before_action :time_now_if_published_at_is_nil, only: :create
-
   def index
     posts = current_user.posts.includes(:author).recent.page(params[:page]).per(params[:per_page])
 
@@ -34,12 +32,6 @@ class Api::V1::Author::PostsController < Api::V1::Author::BaseController
   end
 
   private
-
-  def time_now_if_published_at_is_nil
-    unless params[:published_at].present?
-      params[:published_at] = Time.now
-    end
-  end
 
   def post_params
     params.permit(:title, :body, :published_at)

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -11,6 +11,11 @@ class Api::V1::BaseController < ActionController::Base
            status: status_code
   end
 
+  def render_success(data, status_code=200)
+    render json: { data: data },
+           status: status_code
+  end
+
   def user_not_authenticated
     render_error 'Not Authenticated', 401
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,6 @@
+class Comment < ApplicationRecord
+  belongs_to :author, class_name: 'User'
+  belongs_to :commentable, polymorphic: true
+
+  validates :body, presence: true
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,4 +5,14 @@ class Post < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
 
   scope :recent, -> { order(published_at: :desc) }
+
+  before_create :time_now_if_published_at_is_nil
+
+  private
+
+  def time_now_if_published_at_is_nil
+    unless published_at.present?
+      self.published_at = Time.now
+    end
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,7 @@
 class Post < ApplicationRecord
-  belongs_to :author, class_name: 'User', foreign_key: :author_id
+  belongs_to :author, class_name: 'User'
+
+  has_many :comments, as: :commentable
 
   validates :body, presence: true
   validates :title, presence: true, length: { maximum: 100 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,8 @@
 class Post < ApplicationRecord
   belongs_to :author, class_name: 'User', foreign_key: :author_id
 
-  validates :body, :title, presence: true
+  validates :body, presence: true
+  validates :title, presence: true, length: { maximum: 100 }
 
   scope :recent, -> { order(published_at: :desc) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :posts, foreign_key: :author_id, dependent: :destroy
+  has_many :comments, foreign_key: :author_id, dependent: :destroy
 
   before_save  :ensure_authentication_token
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
       scope module: 'author' do
         resources :posts, only: [:index, :show, :create], param: :post_id
+        resource  :comments, only: [:create, :destroy]
       end
     end
   end

--- a/db/migrate/20171007163507_change_type_for_body_of_posts.rb
+++ b/db/migrate/20171007163507_change_type_for_body_of_posts.rb
@@ -1,0 +1,5 @@
+class ChangeTypeForBodyOfPosts < ActiveRecord::Migration[5.1]
+  def change
+    change_column :posts, :body, :text
+  end
+end

--- a/db/migrate/20171007165621_create_comments.rb
+++ b/db/migrate/20171007165621_create_comments.rb
@@ -1,0 +1,15 @@
+class CreateComments < ActiveRecord::Migration[5.1]
+  def change
+    create_table :comments do |t|
+      t.text :body, null: false
+      t.integer :author_id
+      t.integer :commentable_id
+      t.string  :commentable_type
+
+      t.timestamps
+    end
+
+    add_index :comments, :author_id
+    add_index :comments, [:commentable_id, :commentable_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171007163507) do
+ActiveRecord::Schema.define(version: 20171007165621) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "comments", force: :cascade do |t|
+    t.text "body", null: false
+    t.integer "author_id"
+    t.integer "commentable_id"
+    t.string "commentable_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_comments_on_author_id"
+    t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005155907) do
+ActiveRecord::Schema.define(version: 20171007163507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "posts", force: :cascade do |t|
     t.string "title", null: false
-    t.string "body", null: false
+    t.text "body", null: false
     t.integer "author_id"
     t.datetime "published_at"
     t.datetime "created_at", null: false

--- a/spec/controllers/api/v1/author/comments_controller_spec.rb
+++ b/spec/controllers/api/v1/author/comments_controller_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe Api::V1::Author::CommentsController, type: :request do
+  let(:user) { create :user, email: 'blog@email.example' }
+  let!(:auth_token) { { 'X-Auth-Token': user.authentication_token } }
+
+  describe 'POST #create' do
+    before { post '/api/v1/comments', params: params, headers: json_request_headers.merge!(auth_token) }
+
+    context 'when success' do
+      let(:post_new) { create :post }
+      let(:params) { { comment: { body: 'Body' }, post_id: post_new.id }.to_json }
+
+      specify do
+        expect(response.body).to eq({
+                                       data: 'Comment was succesfully created'
+                                    }.to_json)
+        expect(response).to have_http_status(201)
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+
+    context 'when failure' do
+      context 'when body is nil' do
+        let(:post_new) { create :post }
+        let(:params) { { comment: { body: '' }, post_id: post_new.id }.to_json }
+
+        specify do
+          expect(response.body).to eq({
+                                         errors: ['Body can\'t be blank']
+                                      }.to_json)
+          expect(response).to have_http_status(406)
+          expect(response.content_type).to eq('application/json')
+        end
+      end
+
+      context 'when post_id is nil' do
+        let(:params) { { comment: { body: 'Body' }, post_id: '' }.to_json }
+
+        specify do
+          expect(response.body).to eq({
+                                         error: { message: 'Post not found' }
+                                      }.to_json)
+          expect(response).to have_http_status(406)
+          expect(response.content_type).to eq('application/json')
+        end
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before { delete '/api/v1/comments', params: params, headers: json_request_headers.merge!(auth_token) }
+
+    context 'when success' do
+      let(:comment) { create :comment, author: user }
+      let(:params) { { comment_id: comment.id } }
+
+      specify do
+        expect(response.body).to eq({
+                                       data: 'Comment was succesfully destroyed'
+                                    }.to_json)
+        expect(response).to have_http_status(200)
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+
+    context 'when failure' do
+      let(:params) { { comment_id: '' } }
+
+      specify do
+        expect(response.body).to eq({
+                                       error: { message: 'Comment not found' }
+                                    }.to_json)
+        expect(response).to have_http_status(422)
+        expect(response.content_type).to eq('application/json')
+      end
+    end
+  end
+end

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :comment do
+    body { FFaker::Lorem.paragraph }
+
+    association :author, factory: :user
+
+    before(:create) do |comment|
+      comment.commentable = create(:post)
+    end
+  end
+end

--- a/spec/factories/post.rb
+++ b/spec/factories/post.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :post do
     title        { FFaker::Lorem.sentence }
-    body         { FFaker::Lorem.sentence }
+    body         { FFaker::Lorem.paragraph }
     published_at { Time.now }
 
     association :author, factory: :user

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,9 +4,15 @@ FactoryGirl.define do
     nickname { FFaker::Lorem.word }
     password '111111'
 
-    trait :second_posts do
+    trait :several_posts do
       before(:create) do |user|
         user.posts = create_list :post, 2
+      end
+    end
+
+    trait :several_comments do
+      before(:create) do |user|
+        user.comments = create_list :comment, 2
       end
     end
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  it { is_expected.to validate_presence_of :body }
+  it { is_expected.to belong_to(:author).class_name('User') }
+  it { is_expected.to belong_to(:commentable) }
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Post, type: :model do
   it { is_expected.to validate_presence_of :body }
   it { is_expected.to validate_presence_of :title }
+  it { should validate_length_of(:title).is_at_most(100) }
 
   it do
     is_expected.to belong_to(:author).

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -3,12 +3,9 @@ require 'rails_helper'
 RSpec.describe Post, type: :model do
   it { is_expected.to validate_presence_of :body }
   it { is_expected.to validate_presence_of :title }
-  it { should validate_length_of(:title).is_at_most(100) }
-
-  it do
-    is_expected.to belong_to(:author).
-        class_name('User').with_foreign_key('author_id')
-  end
+  it { is_expected.to validate_length_of(:title).is_at_most(100) }
+  it { is_expected.to belong_to(:author).class_name('User') }
+  it { is_expected.to have_many(:comments) }
 
   describe '#recent' do
     let!(:post_1) { create :post }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,12 +3,21 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   it { is_expected.to validate_presence_of :nickname }
   it { is_expected.to have_many(:posts).with_foreign_key('author_id') }
+  it { is_expected.to have_many(:comments).with_foreign_key('author_id') }
 
   describe 'destoys dependent posts' do
-    let!(:posts) { create(:user, :second_posts) }
+    let!(:posts) { create(:user, :several_posts) }
 
     specify do
       expect { User.last.destroy }.to change { Post.count }.by(-2)
+    end
+  end
+
+  describe 'destoys dependent comments' do
+    let!(:author) { create :user, :several_comments }
+
+    specify do
+      expect { User.last.destroy }.to change { Comment.count }.by(-2)
     end
   end
 


### PR DESCRIPTION
# What was done:
- Changed type for body of post
- Moved callback from posts controller to post model
- Added endpoints for create and destroy comments 
- Added requests and unit tests
